### PR TITLE
add ca-certificates to chain docker image

### DIFF
--- a/chain/Dockerfile
+++ b/chain/Dockerfile
@@ -19,7 +19,7 @@ FROM debian:bookworm-slim AS runtime
 WORKDIR /app
 COPY --from=builder /app/target/release/chain /app/chain
 
-RUN apt-get update && apt-get install -y libpq5
+RUN apt-get update && apt-get install -y libpq5 ca-certificates
 
 WORKDIR /app
 


### PR DESCRIPTION
same as https://github.com/anoma/namada-indexer/pull/87
without this, the crawler is not able to connect HTTPS RPC end-points