### PR TITLE
Fix PostgreSQL parameter limit error in witness map insertion

### DIFF
--- a/chain/src/services/db.rs
+++ b/chain/src/services/db.rs
@@ -269,10 +269,14 @@ fn commit_inner(
                         .values(chunk)
                         .on_conflict_do_nothing()
                         .execute(transaction_conn)
-                        .with_context(|| format!(
-                            "Failed to insert witness batch {} ({} witnesses)",
-                            batch_idx + 1, chunk.len()
-                        ))?;
+                        .with_context(|| {
+                            format!(
+                                "Failed to insert witness batch {} ({} \
+                                 witnesses)",
+                                batch_idx + 1,
+                                chunk.len()
+                            )
+                        })?;
 
                     if total > BATCH_SIZE {
                         tracing::debug!(

--- a/chain/src/services/db.rs
+++ b/chain/src/services/db.rs
@@ -253,16 +253,35 @@ fn commit_inner(
             if let Some(witness_map_db) =
                 witness_map.into_db(chain_state.block_height)
             {
+                let total = witness_map_db.len();
                 tracing::debug!(
                     block_height = %chain_state.block_height,
+                    total_witnesses = total,
                     "Pre-committing witness map"
                 );
 
-                diesel::insert_into(schema::witness::table)
-                    .values(&witness_map_db)
-                    .on_conflict_do_nothing()
-                    .execute(transaction_conn)
-                    .context("Failed to insert witness map into db")?;
+                const BATCH_SIZE: usize = 20000;
+
+                for (batch_idx, chunk) in
+                    witness_map_db.chunks(BATCH_SIZE).enumerate()
+                {
+                    diesel::insert_into(schema::witness::table)
+                        .values(chunk)
+                        .on_conflict_do_nothing()
+                        .execute(transaction_conn)
+                        .with_context(|| format!(
+                            "Failed to insert witness batch {} ({} witnesses)",
+                            batch_idx + 1, chunk.len()
+                        ))?;
+
+                    if total > BATCH_SIZE {
+                        tracing::debug!(
+                            block_height = %chain_state.block_height,
+                            batch = batch_idx + 1,
+                            "Inserted witness batch"
+                        );
+                    }
+                }
 
                 tracing::debug!(
                     block_height = %chain_state.block_height,


### PR DESCRIPTION
## Problem
The MASP indexer crashes when processing blocks with large witness maps (>21,800 witnesses) due to PostgreSQL's 65,535 parameter limit.

Error: `number of parameters must be between 0 and 65535`

## Root Cause
- Each witness insert requires 3 parameters (witness_bytes, witness_idx, block_height)
- Blocks with ~21,844 witnesses = 65,532 parameters in a single INSERT statement
- This exceeds PostgreSQL's limit, causing the indexer to crash and retry indefinitely

## Solution
Implement batched inserts for witness maps:
- Insert witnesses in chunks of 20,000 (60,000 parameters max)
- Stays safely under the 65,535 parameter limit
- Adds logging for batch progress on large witness sets

## Testing
- Tested with snapshot at block 3763785
- Successfully processed block 3763786 (which previously failed)
- Indexer now syncs normally through blocks with large witness maps

## Files Changed
- `chain/src/services/db.rs`: Added batching logic to witness insertion