### PR TITLE
Fix chain_state tracking for empty blocks (v1.4.4)

### DIFF
--- a/chain/src/main.rs
+++ b/chain/src/main.rs
@@ -342,7 +342,8 @@ async fn build_and_commit_masp_data_at_height(
     let num_transactions = block_data.transactions.len();
     let block_height = block_data.header.height;
 
-    // Fast-path: commit empty blocks immediately to maintain chain_state progress
+    // Fast-path: commit empty blocks immediately to maintain chain_state
+    // progress
     if num_transactions == 0 {
         tracing::info!(%block_height, "Processing empty block");
         let chain_state = ChainState::new(block_data.header.height);
@@ -519,11 +520,6 @@ impl FetchedBlocks {
         std::iter::from_fn(|| {
             while let Some(block_data) = unprocessed_blocks.dequeue_next_block()
             {
-                // Check if we can skip committing this block for now.
-                // This is because the block is empty. We can make a
-                // single remote procedure call to Postgres, when we
-                // exit.
-
                 tracing::info!(block_height = %block_data.header.height, "Dequeued block to be processed");
 
                 return Some(block_data);

--- a/chain/src/main.rs
+++ b/chain/src/main.rs
@@ -518,14 +518,12 @@ impl FetchedBlocks {
         }
 
         std::iter::from_fn(|| {
-            while let Some(block_data) = unprocessed_blocks.dequeue_next_block()
-            {
+            if let Some(block_data) = unprocessed_blocks.dequeue_next_block() {
                 tracing::info!(block_height = %block_data.header.height, "Dequeued block to be processed");
-
-                return Some(block_data);
+                Some(block_data)
+            } else {
+                None
             }
-
-            None
         })
     }
 }


### PR DESCRIPTION
## Problem

In v1.4.4, commit `3f9ee6c` introduced an optimization to skip committing empty blocks. However, this caused `chain_state` to stop updating during sequences of empty blocks, making the indexer appear frozen even though it continued processing blocks internally.

**Impact:**
- Operators cannot monitor indexer progress through empty block sequences
- Impossible to distinguish between a working indexer and a crashed one
- Health checks fail incorrectly
- API endpoint shows stale height during periods without MASP transactions

## Solution

This fix maintains the performance optimization while ensuring `chain_state` updates for all blocks by:
* Adding fast-path commit for empty blocks (skips expensive MASP processing)
* Removing the skip logic that prevented `chain_state` updates
* Preserving API visibility of indexer progress

Fixes progress tracking regression introduced in v1.4.4.

## Testing

**Checked on Mainnet:** `namada.5f5de2dd1b88cba30586420`
- Masp-indexer endpoint: https://masp-indexer.papadritta.com/api/v1/height
- Verified `chain_state` updates continuously through empty blocks

**Checked on Testnet:** `housefire-alpaca.cc0d3e0c033be`
- Masp-indexer endpoint: https://housefire.masp-indexer.papadritta.com/api/v1/height
- Confirmed indexer maintains progress visibility

Both deployments show correct behavior with the fix applied.